### PR TITLE
Add support for nesting within LayerGroup component

### DIFF
--- a/src/GeoJsonCluster.js
+++ b/src/GeoJsonCluster.js
@@ -19,5 +19,5 @@ export class GeoJsonCluster extends PopupContainer {
 
 GeoJsonCluster.propTypes = {
   data: PropTypes.object.isRequired,
-  layerGroup: PropTypes.object.isOptional,
+  layerGroup: PropTypes.object,
 };

--- a/src/GeoJsonCluster.js
+++ b/src/GeoJsonCluster.js
@@ -11,12 +11,13 @@ export class GeoJsonCluster extends PopupContainer {
 
   componentDidUpdate() {
     const { data, map, ...props } = this.props;
-    map.removeLayer(this.leafletElement);
+    (this.props.layerGroup || map).removeLayer(this.leafletElement);
     this.leafletElement = cluster(data, props);
-    map.addLayer(this.leafletElement);
+    (this.props.layerGroup || map).addLayer(this.leafletElement);
   }
 }
 
 GeoJsonCluster.propTypes = {
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  layerGroup: PropTypes.object.isOptional,
 };


### PR DESCRIPTION
This adds support for `LayerGroup` from `react-leaflet` so you can nest this as such:

``` js
<LayerGroup>
    <GeoJsonCluster data={ data }/>
</LayerGroup>
```

Before it would break whenever `componentDidUpdate` was called because the references within `this.props.layerGroup._layers` would not be linked properly.

Requires a re-build of the `lib` directory.
